### PR TITLE
Remove semicolon ending from all snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Install via package control, see: `https://sublime.wbond.net/` for more details.
 Changelog
 ---------
 
+### 0.0.3
+
+* Removed semicolon endings to make snippets more generic
+
 ### 0.0.2
 
 * Shortened descriptions of most snippets

--- a/lodash-after.sublime-snippet
+++ b/lodash-after.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.after(${1:n}, ${2:func});
+_.after(${1:n}, ${2:func})
 ]]></content>
   <tabTrigger>_.after</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-assign.sublime-snippet
+++ b/lodash-assign.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.assign(${1:object}${2:, [source]}${3:, [callback]}${4:, [thisArg]});
+_.assign(${1:object}${2:, [source]}${3:, [callback]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.assign</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-at.sublime-snippet
+++ b/lodash-at.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.at(${1:collection}${2:, [index]});
+_.at(${1:collection}${2:, [index]})
 ]]></content>
   <tabTrigger>_.at</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-bind.sublime-snippet
+++ b/lodash-bind.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.bind(${1:func}${2:, [thisArg]}${3:, [arg]});
+_.bind(${1:func}${2:, [thisArg]}${3:, [arg]})
 ]]></content>
   <tabTrigger>_.bind</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-bindAll.sublime-snippet
+++ b/lodash-bindAll.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.bindAll(${1:object}${2:, [methodName]});
+_.bindAll(${1:object}${2:, [methodName]})
 ]]></content>
   <tabTrigger>_.bindAll</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-bindKey.sublime-snippet
+++ b/lodash-bindKey.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.bindKey(${1:object}, ${2:key}${3:, [arg]});
+_.bindKey(${1:object}, ${2:key}${3:, [arg]})
 ]]></content>
   <tabTrigger>_.bindKey</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-chain-short.sublime-snippet
+++ b/lodash-chain-short.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_(${1:value});
+_(${1:value})
 ]]></content>
   <tabTrigger>_</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-chain.sublime-snippet
+++ b/lodash-chain.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.chain(${1:value});
+_.chain(${1:value})
 ]]></content>
   <tabTrigger>_.chain</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-clone.sublime-snippet
+++ b/lodash-clone.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.clone(${1:value}${2:, [deep=false]}${3:, [callback]}${4:, [thisArg]});
+_.clone(${1:value}${2:, [deep=false]}${3:, [callback]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.clone</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-cloneDeep.sublime-snippet
+++ b/lodash-cloneDeep.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.cloneDeep(${1:value}${2:, [callback]}${3:, [thisArg]});
+_.cloneDeep(${1:value}${2:, [callback]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.cloneDeep</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-compact.sublime-snippet
+++ b/lodash-compact.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.compact(${1:array});
+_.compact(${1:array})
 ]]></content>
   <tabTrigger>_.compact</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-compose.sublime-snippet
+++ b/lodash-compose.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.compose(${1:[func]});
+_.compose(${1:[func]})
 ]]></content>
   <tabTrigger>_.compose</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-contains.sublime-snippet
+++ b/lodash-contains.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.contains(${1:collection}, ${2:target}${2:, [fromIndex=0]})
+_.contains(${1:collection}, ${2:target}${3:, [fromIndex=0]})
 ]]></content>
   <tabTrigger>_.contains</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-contains.sublime-snippet
+++ b/lodash-contains.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.contains(${1:collection}, ${2:target}${2:, [fromIndex=0]});
+_.contains(${1:collection}, ${2:target}${2:, [fromIndex=0]})
 ]]></content>
   <tabTrigger>_.contains</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-countBy.sublime-snippet
+++ b/lodash-countBy.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.countBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.countBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.countBy</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-createCallback.sublime-snippet
+++ b/lodash-createCallback.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.createCallback(${1:[func=identity]}${2:, [thisArg]}${3:, [argCount]});
+_.createCallback(${1:[func=identity]}${2:, [thisArg]}${3:, [argCount]})
 ]]></content>
   <tabTrigger>_.createCallback</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-curry.sublime-snippet
+++ b/lodash-curry.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.curry(${1:func}${2:, [arity=func.length]});
+_.curry(${1:func}${2:, [arity=func.length]})
 ]]></content>
   <tabTrigger>_.curry</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-debounce.sublime-snippet
+++ b/lodash-debounce.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.debounce(${1:func}, ${2:wait}${3:, [options]}${4:, [options.maxWait]});
+_.debounce(${1:func}, ${2:wait}${3:, [options]}${4:, [options.maxWait]})
 ]]></content>
   <tabTrigger>_.debounce</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-defaults.sublime-snippet
+++ b/lodash-defaults.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.defaults(${1:object}${2:, [source]});
+_.defaults(${1:object}${2:, [source]})
 ]]></content>
   <tabTrigger>_.defaults</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-defer.sublime-snippet
+++ b/lodash-defer.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.defer(${1:func}${2:, [arg]});
+_.defer(${1:func}${2:, [arg]})
 ]]></content>
   <tabTrigger>_.defer</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-delay.sublime-snippet
+++ b/lodash-delay.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.delay(${1:func}${2:, wait}${3:, [arg]});
+_.delay(${1:func}${2:, wait}${3:, [arg]})
 ]]></content>
   <tabTrigger>_.delay</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-difference.sublime-snippet
+++ b/lodash-difference.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.difference(${1:array}, ${2:array});
+_.difference(${1:array}, ${2:array})
 ]]></content>
   <tabTrigger>_.difference</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-escape.sublime-snippet
+++ b/lodash-escape.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.escape(${1:string});
+_.escape(${1:string})
 ]]></content>
   <tabTrigger>_.escape</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-every.sublime-snippet
+++ b/lodash-every.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.every(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.every(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.every</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-filter.sublime-snippet
+++ b/lodash-filter.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.filter(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.filter(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.filter</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-find.sublime-snippet
+++ b/lodash-find.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.find(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.find(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.find</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-findIndex.sublime-snippet
+++ b/lodash-findIndex.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.findIndex(${1:array}${2:, [callback=identity]}${3:, [thisArg]});
+_.findIndex(${1:array}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.findIndex</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-findKey.sublime-snippet
+++ b/lodash-findKey.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.findKey(${1:object}${2:, [callback=identity]}${3:, [thisArg]});
+_.findKey(${1:object}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.findKey</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-findLast.sublime-snippet
+++ b/lodash-findLast.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.findLast(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.findLast(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.findLast</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-findLastIndex.sublime-snippet
+++ b/lodash-findLastIndex.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.findLastIndex(${1:array}${2:, [callback=identity]}${3:, [thisArg]});
+_.findLastIndex(${1:array}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.findLastIndex</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-findLastKey.sublime-snippet
+++ b/lodash-findLastKey.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.findLastKey(${1:object}${2:, [callback=identity]}${3:, [thisArg]});
+_.findLastKey(${1:object}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.findLastKey</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-first.sublime-snippet
+++ b/lodash-first.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.first(${1:array}${2:,[callback]}${3:,[thisArg]});
+_.first(${1:array}${2:,[callback]}${3:,[thisArg]})
 ]]></content>
   <tabTrigger>_.first</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-flatten.sublime-snippet
+++ b/lodash-flatten.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.flatten(${1:array}${2:,[isShallow=false]}${3:,[callback=identity]}${4:,[thisArg]});
+_.flatten(${1:array}${2:,[isShallow=false]}${3:,[callback=identity]}${4:,[thisArg]})
 ]]></content>
   <tabTrigger>_.flatten</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-forEach.sublime-snippet
+++ b/lodash-forEach.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.forEach(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.forEach(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.forEach</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-forEachRight.sublime-snippet
+++ b/lodash-forEachRight.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.forEachRight(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.forEachRight(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.forEachRight</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-forIn.sublime-snippet
+++ b/lodash-forIn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.forIn(${1:object}${2:, [callback=identity]}${3:, [thisArg]});
+_.forIn(${1:object}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.forIn</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-forInRight.sublime-snippet
+++ b/lodash-forInRight.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.forInRight(${1:object}${2:, [callback=identity]}${3:, [thisArg]});
+_.forInRight(${1:object}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.forInRight</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-forOwn.sublime-snippet
+++ b/lodash-forOwn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.forOwn(${1:object}${2:, [callback=identity]}${3:, [thisArg]});
+_.forOwn(${1:object}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.forOwn</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-forOwnRight.sublime-snippet
+++ b/lodash-forOwnRight.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.forOwnRight(${1:object}${2:, [callback=identity]}${3:, [thisArg]});
+_.forOwnRight(${1:object}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.forOwnRight</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-functions.sublime-snippet
+++ b/lodash-functions.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.functions(${1:object});
+_.functions(${1:object})
 ]]></content>
   <tabTrigger>_.functions</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-groupBy.sublime-snippet
+++ b/lodash-groupBy.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.groupBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.groupBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.groupBy</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-has.sublime-snippet
+++ b/lodash-has.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.has(${1:object}, ${2:property});
+_.has(${1:object}, ${2:property})
 ]]></content>
   <tabTrigger>_.has</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-identity.sublime-snippet
+++ b/lodash-identity.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.identity(${1:value});
+_.identity(${1:value})
 ]]></content>
   <tabTrigger>_.identity</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-indexBy.sublime-snippet
+++ b/lodash-indexBy.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.indexBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.indexBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.indexBy</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-indexOf.sublime-snippet
+++ b/lodash-indexOf.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.indexOf(${1:array}, ${2:value}${3:,[fromIndex=0]});
+_.indexOf(${1:array}, ${2:value}${3:,[fromIndex=0]})
 ]]></content>
   <tabTrigger>_.indexOf</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-initial.sublime-snippet
+++ b/lodash-initial.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.initial(${1:array}${2:, [callback=1]}${3:, [thisArg]});
+_.initial(${1:array}${2:, [callback=1]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.initial</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-intersection.sublime-snippet
+++ b/lodash-intersection.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.intersection(${1:[array]});
+_.intersection(${1:[array]})
 ]]></content>
   <tabTrigger>_.intersection</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-invert.sublime-snippet
+++ b/lodash-invert.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.invert(${1:object});
+_.invert(${1:object})
 ]]></content>
   <tabTrigger>_.invert</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-invoke.sublime-snippet
+++ b/lodash-invoke.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.invoke(${1:collection}, ${2:methodName}${3:, [arg]});
+_.invoke(${1:collection}, ${2:methodName}${3:, [arg]})
 ]]></content>
   <tabTrigger>_.invoke</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isArguments.sublime-snippet
+++ b/lodash-isArguments.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isArguments(${1:value});
+_.isArguments(${1:value})
 ]]></content>
   <tabTrigger>_.isArguments</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isArray.sublime-snippet
+++ b/lodash-isArray.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isArray(${1:value});
+_.isArray(${1:value})
 ]]></content>
   <tabTrigger>_.isArray</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isBoolean.sublime-snippet
+++ b/lodash-isBoolean.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isBoolean(${1:value});
+_.isBoolean(${1:value})
 ]]></content>
   <tabTrigger>_.isBoolean</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isDate.sublime-snippet
+++ b/lodash-isDate.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isDate(${1:value});
+_.isDate(${1:value})
 ]]></content>
   <tabTrigger>_.isDate</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isElement.sublime-snippet
+++ b/lodash-isElement.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isElement(${1:value});
+_.isElement(${1:value})
 ]]></content>
   <tabTrigger>_.isElement</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isEmpty.sublime-snippet
+++ b/lodash-isEmpty.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isEmpty(${1:value});
+_.isEmpty(${1:value})
 ]]></content>
   <tabTrigger>_.isEmpty</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isEqual.sublime-snippet
+++ b/lodash-isEqual.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isEqual(${1:a}, ${2:b}${3:, [callback]}${4:, [thisArg]});
+_.isEqual(${1:a}, ${2:b}${3:, [callback]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.isEqual</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isFinite.sublime-snippet
+++ b/lodash-isFinite.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isFinite(${1:value});
+_.isFinite(${1:value})
 ]]></content>
   <tabTrigger>_.isFinite</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isFunction.sublime-snippet
+++ b/lodash-isFunction.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isFunction(${1:value});
+_.isFunction(${1:value})
 ]]></content>
   <tabTrigger>_.isFunction</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isNaN.sublime-snippet
+++ b/lodash-isNaN.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isNaN(${1:value});
+_.isNaN(${1:value})
 ]]></content>
   <tabTrigger>_.isNaN</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isNull.sublime-snippet
+++ b/lodash-isNull.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isNull(${1:value});
+_.isNull(${1:value})
 ]]></content>
   <tabTrigger>_.isNull</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isNumber.sublime-snippet
+++ b/lodash-isNumber.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isNumber(${1:value});
+_.isNumber(${1:value})
 ]]></content>
   <tabTrigger>_.isNumber</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isObject.sublime-snippet
+++ b/lodash-isObject.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isObject(${1:value});
+_.isObject(${1:value})
 ]]></content>
   <tabTrigger>_.isObject</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isPlainObject.sublime-snippet
+++ b/lodash-isPlainObject.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isPlainObject(${1:value});
+_.isPlainObject(${1:value})
 ]]></content>
   <tabTrigger>_.isPlainObject</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isRegExp.sublime-snippet
+++ b/lodash-isRegExp.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isRegExp(${1:value});
+_.isRegExp(${1:value})
 ]]></content>
   <tabTrigger>_.isRegExp</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isString.sublime-snippet
+++ b/lodash-isString.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isString(${1:value});
+_.isString(${1:value})
 ]]></content>
   <tabTrigger>_.isString</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-isUndefined.sublime-snippet
+++ b/lodash-isUndefined.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.isUndefined(${1:value});
+_.isUndefined(${1:value})
 ]]></content>
   <tabTrigger>_.isUndefined</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-keys.sublime-snippet
+++ b/lodash-keys.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.keys(${1:object});
+_.keys(${1:object})
 ]]></content>
   <tabTrigger>_.keys</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-last.sublime-snippet
+++ b/lodash-last.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.last(${1:array}${2:, [callback]}${3:, [thisArg]});
+_.last(${1:array}${2:, [callback]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.last</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-lastIndexOf.sublime-snippet
+++ b/lodash-lastIndexOf.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.lastIndexOf(${1:array}, ${2:value}${3:, [fromIndex=array.length-1]});
+_.lastIndexOf(${1:array}, ${2:value}${3:, [fromIndex=array.length-1]})
 ]]></content>
   <tabTrigger>_.lastIndexOf</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-map.sublime-snippet
+++ b/lodash-map.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.map(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.map(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.map</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-max.sublime-snippet
+++ b/lodash-max.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.max(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.max(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.max</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-memoize.sublime-snippet
+++ b/lodash-memoize.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.memoize(${1:func}${2:, [resolver]}});
+_.memoize(${1:func}${2:, [resolver]}})
 ]]></content>
   <tabTrigger>_.memoize</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-merge.sublime-snippet
+++ b/lodash-merge.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.merge(${1:object}${2:, [source]}${3:, [callback]}${4:, [thisArg]});
+_.merge(${1:object}${2:, [source]}${3:, [callback]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.merge</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-min.sublime-snippet
+++ b/lodash-min.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.min(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.min(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.min</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-mixin.sublime-snippet
+++ b/lodash-mixin.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.mixin(${1:object}, ${2:object});
+_.mixin(${1:object}, ${2:object})
 ]]></content>
   <tabTrigger>_.mixin</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-noConflict.sublime-snippet
+++ b/lodash-noConflict.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.noConflict();
+_.noConflict()
 ]]></content>
   <tabTrigger>_.noConflict</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-omit.sublime-snippet
+++ b/lodash-omit.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.omit(${1:object}${2:, [callback]}${3:, [thisArg]});
+_.omit(${1:object}${2:, [callback]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.omit</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-once.sublime-snippet
+++ b/lodash-once.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.once(${1:func});
+_.once(${1:func})
 ]]></content>
   <tabTrigger>_.once</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-pairs.sublime-snippet
+++ b/lodash-pairs.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.pairs(${1:object});
+_.pairs(${1:object})
 ]]></content>
   <tabTrigger>_.pairs</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-parseInt.sublime-snippet
+++ b/lodash-parseInt.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.parseInt(${1:value}${2:, [radix]]});
+_.parseInt(${1:value}${2:, [radix]]})
 ]]></content>
   <tabTrigger>_.parseInt</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-partial.sublime-snippet
+++ b/lodash-partial.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.partial(${1:func}${2:, [arg]});
+_.partial(${1:func}${2:, [arg]})
 ]]></content>
   <tabTrigger>_.partial</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-partialRight.sublime-snippet
+++ b/lodash-partialRight.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.partialRight(${1:func}${2:, [arg]});
+_.partialRight(${1:func}${2:, [arg]})
 ]]></content>
   <tabTrigger>_.partialRight</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-pick.sublime-snippet
+++ b/lodash-pick.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.pick(${1:object}${2:, [callback]}${3:, [thisArg]});
+_.pick(${1:object}${2:, [callback]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.pick</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-pluck.sublime-snippet
+++ b/lodash-pluck.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.pluck(${1:collection}, ${2:property});
+_.pluck(${1:collection}, ${2:property})
 ]]></content>
   <tabTrigger>_.pluck</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-pull.sublime-snippet
+++ b/lodash-pull.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.pull(${1:array}${2:, [value]});
+_.pull(${1:array}${2:, [value]})
 ]]></content>
   <tabTrigger>_.pull</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-random.sublime-snippet
+++ b/lodash-random.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.random(${1:[min=0]}${2:, [max=1]}${3:, [floating=false]});
+_.random(${1:[min=0]}${2:, [max=1]}${3:, [floating=false]})
 ]]></content>
   <tabTrigger>_.random</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-range.sublime-snippet
+++ b/lodash-range.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.range(${1:[start=0]}${2:, end}${3:, [step=1]});
+_.range(${1:[start=0]}${2:, end}${3:, [step=1]})
 ]]></content>
   <tabTrigger>_.range</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-reduce.sublime-snippet
+++ b/lodash-reduce.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.reduce(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]});
+_.reduce(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.reduce</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-reduceRight.sublime-snippet
+++ b/lodash-reduceRight.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.reduceRight(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]});
+_.reduceRight(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.reduceRight</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-reject.sublime-snippet
+++ b/lodash-reject.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.reject(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]});
+_.reject(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.reject</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-remove.sublime-snippet
+++ b/lodash-remove.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.remove(${1:array}${2:, [callback=1]}${3:, [thisArg]});
+_.remove(${1:array}${2:, [callback=1]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.remove</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-rest.sublime-snippet
+++ b/lodash-rest.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.rest(${1:array}${2:, [callback=1]}${3:, [thisArg]});
+_.rest(${1:array}${2:, [callback=1]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.rest</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-result.sublime-snippet
+++ b/lodash-result.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.result(${1:object}, ${2:property});
+_.result(${1:object}, ${2:property})
 ]]></content>
   <tabTrigger>_.result</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-runInContext.sublime-snippet
+++ b/lodash-runInContext.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.runInContext(${1:[context=root]});
+_.runInContext(${1:[context=root]})
 ]]></content>
   <tabTrigger>_.runInContext</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-sample.sublime-snippet
+++ b/lodash-sample.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.sample(${1:collection}${2:, [n]});
+_.sample(${1:collection}${2:, [n]})
 ]]></content>
   <tabTrigger>_.sample</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-shuffle.sublime-snippet
+++ b/lodash-shuffle.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.shuffle(${1:collection});
+_.shuffle(${1:collection})
 ]]></content>
   <tabTrigger>_.shuffle</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-size.sublime-snippet
+++ b/lodash-size.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.size(${1:collection});
+_.size(${1:collection})
 ]]></content>
   <tabTrigger>_.size</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-some.sublime-snippet
+++ b/lodash-some.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.some(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.some(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.some</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-sortBy.sublime-snippet
+++ b/lodash-sortBy.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.sortBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]});
+_.sortBy(${1:collection}${2:, [callback=identity]}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.sortBy</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-sortedIndex.sublime-snippet
+++ b/lodash-sortedIndex.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.sortedIndex(${1:array}, ${2:value}${3:, [callback=identity]}${4:, [thisArg]});
+_.sortedIndex(${1:array}, ${2:value}${3:, [callback=identity]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.sortedIndex</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-tap.sublime-snippet
+++ b/lodash-tap.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.tap(${1:value}, ${2:interceptor});
+_.tap(${1:value}, ${2:interceptor})
 ]]></content>
   <tabTrigger>_.tap</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-template.sublime-snippet
+++ b/lodash-template.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.template(${1:text}, ${2:data}${3:, [options]}${4:, [options.escape]}${5:, [options.evaluate]}${6:, [options.imports]}${7:, [options.interpolate]}${8:, [sourceURL]}${9:, [variable]});
+_.template(${1:text}, ${2:data}${3:, [options]}${4:, [options.escape]}${5:, [options.evaluate]}${6:, [options.imports]}${7:, [options.interpolate]}${8:, [sourceURL]}${9:, [variable]})
 ]]></content>
   <tabTrigger>_.template</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-throttle.sublime-snippet
+++ b/lodash-throttle.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.throttle(${1:func}, ${2:wait}${3:, [options]});
+_.throttle(${1:func}, ${2:wait}${3:, [options]})
 ]]></content>
   <tabTrigger>_.throttle</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-times.sublime-snippet
+++ b/lodash-times.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.times(${1:n}, ${2:callback}${3:, [thisArg]});
+_.times(${1:n}, ${2:callback}${3:, [thisArg]})
 ]]></content>
   <tabTrigger>_.times</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-toArray.sublime-snippet
+++ b/lodash-toArray.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.toArray(${1:collection});
+_.toArray(${1:collection})
 ]]></content>
   <tabTrigger>_.toArray</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-transform.sublime-snippet
+++ b/lodash-transform.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.transform(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]});
+_.transform(${1:collection}${2:, [callback=identity]}${3:, [accumulator]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.transform</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-unescape.sublime-snippet
+++ b/lodash-unescape.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.unescape(${1:string});
+_.unescape(${1:string})
 ]]></content>
   <tabTrigger>_.unescape</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-union.sublime-snippet
+++ b/lodash-union.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.union(${1:[array]});
+_.union(${1:[array]})
 ]]></content>
   <tabTrigger>_.union</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-uniq.sublime-snippet
+++ b/lodash-uniq.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.uniq(${1:array}${2:, [isSorted=false]}${3:, [callback=identity]}${4:, [thisArg]});
+_.uniq(${1:array}${2:, [isSorted=false]}${3:, [callback=identity]}${4:, [thisArg]})
 ]]></content>
   <tabTrigger>_.uniq</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-uniqueId.sublime-snippet
+++ b/lodash-uniqueId.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.uniqueId(${1:[prefix]});
+_.uniqueId(${1:[prefix]})
 ]]></content>
   <tabTrigger>_.uniqueId</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-values.sublime-snippet
+++ b/lodash-values.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.values(${1:object});
+_.values(${1:object})
 ]]></content>
   <tabTrigger>_.values</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-where.sublime-snippet
+++ b/lodash-where.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.where(${1:collection}, ${2:properties});
+_.where(${1:collection}, ${2:properties})
 ]]></content>
   <tabTrigger>_.where</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-without.sublime-snippet
+++ b/lodash-without.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.without(${1:array}${2:, [value]});
+_.without(${1:array}${2:, [value]})
 ]]></content>
   <tabTrigger>_.without</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-wrap.sublime-snippet
+++ b/lodash-wrap.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.wrap(${1:value}, ${2:wrapper});
+_.wrap(${1:value}, ${2:wrapper})
 ]]></content>
   <tabTrigger>_.wrap</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-zip.sublime-snippet
+++ b/lodash-zip.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.zip(${1:[array]});
+_.zip(${1:[array]})
 ]]></content>
   <tabTrigger>_.zip</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->

--- a/lodash-zipObject.sublime-snippet
+++ b/lodash-zipObject.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-_.zipObject(${1:keys}${2:, [values=[]]});
+_.zipObject(${1:keys}${2:, [values=[]]})
 ]]></content>
   <tabTrigger>_.zipObject</tabTrigger>
   <!-- <scope>source.JavaScript</scope> -->


### PR DESCRIPTION
I think it is too opinionated to include semicolons at the end of the snippets. I often found myself having to move or delete the semicolon because I was using a lodash function in a conditional or chaining it with another call, for example. I removed the semicolon endings in an effort to make the snippets more generic.
